### PR TITLE
Setup optimizations

### DIFF
--- a/backend/course-manager-microservice/src/main/liberty/config/server.xml
+++ b/backend/course-manager-microservice/src/main/liberty/config/server.xml
@@ -22,5 +22,5 @@
 
     <ssl id="defaultSSLConfig" trustDefaultCerts="true"/>
 
-    <mpJwt id="cpr22s_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="edu.oswego.cs_CPR.22S.480" audiences="CPR.22S.480" jwksUri="${JWKS_URI}"/>
+    <mpJwt id="cpr_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="cpr" audiences="cpr" jwksUri="${URL}/jwt/ibm/api/cpr_access/jwk"/>
 </server>

--- a/backend/course-viewer-microservice/src/main/liberty/config/server.xml
+++ b/backend/course-viewer-microservice/src/main/liberty/config/server.xml
@@ -22,5 +22,5 @@
 
     <ssl id="defaultSSLConfig" trustDefaultCerts="true"/>
 
-    <mpJwt id="cpr22s_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="edu.oswego.cs_CPR.22S.480" audiences="CPR.22S.480" jwksUri="${JWKS_URI}"/>
+    <mpJwt id="cpr_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="cpr" audiences="cpr" jwksUri="${URL}/jwt/ibm/api/cpr_access/jwk"/>
 </server>

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/rest/services/AuthServices.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/rest/services/AuthServices.java
@@ -52,23 +52,23 @@ public class AuthServices {
         Set<String> roles = getRoles(lakerID);
         
         try {
-            String access_token = JwtBuilder.create("cpr22s_access")
+            String access_token = JwtBuilder.create("cpr_access")
                     .claim("sub", payload.getSubject())
                     .claim("upn", payload.getEmail())
                     .claim("full_name", payload.get("name"))
                     .claim("laker_id", lakerID)
                     .claim("groups", roles)
-                    .claim("aud", "CPR.22S.480")
-                    .claim("iss", "edu.oswego.cs_CPR.22S.480")
+                    .claim("aud", "cpr")
+                    .claim("iss", "cpr")
                     .buildJwt().compact();
 
-            String refresh_token = JwtBuilder.create("cpr22s_refresh")
+            String refresh_token = JwtBuilder.create("cpr_refresh")
                     .claim("sub", payload.getSubject())
                     .claim("upn", payload.getEmail())
                     .claim("full_name", payload.get("name"))
-                    .claim("aud", "CPR.22S.480_refresher")
                     .claim("groups", Collections.singleton("lakers"))
-                    .claim("iss", "edu.oswego.cs_CPR.22S.480_refresher")
+                    .claim("aud", "cpr")
+                    .claim("iss", "cpr")
                     .buildJwt().compact();
 
             tokens.put("access_token", access_token);
@@ -94,14 +94,14 @@ public class AuthServices {
         Set<String> roles = getRoles(lakerID);
         
         try {
-            String access_token = JwtBuilder.create("cpr22s_access")
+            String access_token = JwtBuilder.create("cpr_access")
                     .claim("sub", payload.getSubject())
                     .claim("upn", payload.getName())
                     .claim("full_name", payload.getClaim("full_name"))
                     .claim("laker_id", lakerID)
                     .claim("groups", roles)
-                    .claim("aud", "CPR.22S.480")
-                    .claim("iss", "edu.oswego.cs_CPR.22S.480")
+                    .claim("aud", "cpr")
+                    .claim("iss", "cpr")
                     .buildJwt().compact();
             tokens.put("access_token", access_token);
         } catch (JwtException | InvalidBuilderException | InvalidClaimException e) {

--- a/backend/login-microservice/src/main/liberty/config/server.xml
+++ b/backend/login-microservice/src/main/liberty/config/server.xml
@@ -20,10 +20,10 @@
     <basicRegistry />
     <applicationManager autoExpand="true"/>
 
-    <jwtBuilder id="cpr22s_access" expiresInSeconds="3600" jwkEnabled="true" signatureAlgorithm="RS512"/>
-    <jwtBuilder id="cpr22s_refresh" expiry="72h" jwkEnabled="true" signatureAlgorithm="RS512"/>
+    <jwtBuilder id="cpr_access" expiresInSeconds="3600" jwkEnabled="true" signatureAlgorithm="RS512"/>
+    <jwtBuilder id="cpr_refresh" expiry="72h" jwkEnabled="true" signatureAlgorithm="RS512"/>
 
-    <mpJwt id="cpr22s_refresh" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="edu.oswego.cs_CPR.22S.480_refresher" audiences="CPR.22S.480_refresher" jwksUri="${JWKS_REFRESH_URI}"/>
+    <mpJwt id="cpr_refresh" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="cpr" audiences="cpr" jwksUri="${URL}/jwt/ibm/api/cpr_refresh/jwk"/>
 
     <webApplication contextRoot="${app.context.root}" location="login-microservice.war" />
         

--- a/backend/peer-review-teams-microservice/src/main/liberty/config/server.xml
+++ b/backend/peer-review-teams-microservice/src/main/liberty/config/server.xml
@@ -22,5 +22,5 @@
 
     <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 
-    <mpJwt id="cpr22s_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="edu.oswego.cs_CPR.22S.480" audiences="CPR.22S.480" jwksUri="${JWKS_URI}"/>
+    <mpJwt id="cpr_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="cpr" audiences="cpr" jwksUri="${URL}/jwt/ibm/api/cpr_access/jwk"/>
 </server>

--- a/backend/professor-assignment-microservice/src/main/liberty/config/server.xml
+++ b/backend/professor-assignment-microservice/src/main/liberty/config/server.xml
@@ -22,5 +22,5 @@
 
     <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 
-    <mpJwt id="cpr22s_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="edu.oswego.cs_CPR.22S.480" audiences="CPR.22S.480" jwksUri="${JWKS_URI}"/>
+    <mpJwt id="cpr_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="cpr" audiences="cpr" jwksUri="${URL}/jwt/ibm/api/cpr_access/jwk"/>
 </server>

--- a/backend/student-assignment-microservice/src/main/liberty/config/server.xml
+++ b/backend/student-assignment-microservice/src/main/liberty/config/server.xml
@@ -22,5 +22,5 @@
 
     <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 
-    <mpJwt id="cpr22s_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="edu.oswego.cs_CPR.22S.480" audiences="CPR.22S.480" jwksUri="${JWKS_URI}"/>
+    <mpJwt id="cpr_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="cpr" audiences="cpr" jwksUri="${URL}/jwt/ibm/api/cpr_access/jwk"/>
 </server>

--- a/backend/student-peer-review-assignment-microservice/src/main/liberty/config/server.xml
+++ b/backend/student-peer-review-assignment-microservice/src/main/liberty/config/server.xml
@@ -23,5 +23,5 @@
 
     <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 
-    <mpJwt id="cpr22s_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="edu.oswego.cs_CPR.22S.480" audiences="CPR.22S.480" jwksUri="${JWKS_URI}"/>
+    <mpJwt id="cpr_access" signatureAlgorithm="RS512" tokenHeader="Authorization" issuer="cpr" audiences="cpr" jwksUri="${URL}/jwt/ibm/api/cpr_access/jwk"/>
 </server>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - ./professor-list.txt:/opt/ol/wlp/output/defaultServer/professor-list.txt:rw
     environment:
+      URL: ${URL}
       MONGO_HOSTNAME: ${MONGO_HOSTNAME}
       MONGO_PORT: ${MONGO_PORT}
       MONGO2_PORT: ${MONGO2_PORT}
@@ -28,7 +29,6 @@ services:
       MONGO_PASSWORD: ${MONGO_PASSWORD}
       CLIENT_ID: ${CLIENT_ID}
       CLIENT_SECRET: ${CLIENT_SECRET}
-      URL: ${URL}
 
   course-manager:
     build:
@@ -36,6 +36,7 @@ services:
     container_name: cpr-course-manager
     restart: unless-stopped
     environment:
+      URL: ${URL}
       MONGO_HOSTNAME: ${MONGO_HOSTNAME}
       MONGO_PORT: ${MONGO_PORT}
       MONGO2_PORT: ${MONGO2_PORT}
@@ -45,7 +46,6 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      URL: ${URL}
 
   course-viewer:
     build:
@@ -53,6 +53,7 @@ services:
     container_name: cpr-course-viewer
     restart: unless-stopped
     environment:
+      URL: ${URL}
       MONGO_HOSTNAME: ${MONGO_HOSTNAME}
       MONGO_PORT: ${MONGO_PORT}
       MONGO2_PORT: ${MONGO2_PORT}
@@ -62,7 +63,6 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      URL: ${URL}
 
   peer-review-teams:
     build:
@@ -70,6 +70,7 @@ services:
     container_name: cpr-peer-review-teams
     restart: unless-stopped
     environment:
+      URL: ${URL}
       MONGO_HOSTNAME: ${MONGO_HOSTNAME}
       MONGO_PORT: ${MONGO_PORT}
       MONGO2_PORT: ${MONGO2_PORT}
@@ -79,7 +80,6 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      URL: ${URL}
 
   professor-assignment:
     build:
@@ -89,6 +89,7 @@ services:
     volumes:
       - ./assignments:/opt/ol/wlp/output/defaultServer/assignments
     environment:
+      URL: ${URL}
       MONGO_HOSTNAME: ${MONGO_HOSTNAME}
       MONGO_PORT: ${MONGO_PORT}
       MONGO2_PORT: ${MONGO2_PORT}
@@ -98,7 +99,6 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      URL: ${URL}
 
   student-assignment:
     build:
@@ -108,6 +108,7 @@ services:
     volumes:
       - ./assignments:/opt/ol/wlp/output/defaultServer/assignments
     environment:
+      URL: ${URL}
       MONGO_HOSTNAME: ${MONGO_HOSTNAME}
       MONGO_PORT: ${MONGO_PORT}
       MONGO2_PORT: ${MONGO2_PORT}
@@ -117,7 +118,6 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      URL: ${URL}
 
   student-peer-review-assignment:
     build:
@@ -127,6 +127,7 @@ services:
     volumes:
       - ./assignments:/opt/ol/wlp/output/defaultServer/assignments
     environment:
+      URL: ${URL}
       MONGO_HOSTNAME: ${MONGO_HOSTNAME}
       MONGO_PORT: ${MONGO_PORT}
       MONGO2_PORT: ${MONGO2_PORT}
@@ -136,7 +137,6 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      URL: ${URL}
 
   mongo:
     image: mongo:5.0.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       MONGO_PASSWORD: ${MONGO_PASSWORD}
       CLIENT_ID: ${CLIENT_ID}
       CLIENT_SECRET: ${CLIENT_SECRET}
-      JWKS_REFRESH_URI: ${JWKS_REFRESH_URI}
+      URL: ${URL}
 
   course-manager:
     build:
@@ -45,7 +45,7 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      JWKS_URI: ${JWKS_URI}
+      URL: ${URL}
 
   course-viewer:
     build:
@@ -62,7 +62,7 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      JWKS_URI: ${JWKS_URI}
+      URL: ${URL}
 
   peer-review-teams:
     build:
@@ -79,7 +79,7 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      JWKS_URI: ${JWKS_URI}
+      URL: ${URL}
 
   professor-assignment:
     build:
@@ -98,7 +98,7 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      JWKS_URI: ${JWKS_URI}
+      URL: ${URL}
 
   student-assignment:
     build:
@@ -117,7 +117,7 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      JWKS_URI: ${JWKS_URI}
+      URL: ${URL}
 
   student-peer-review-assignment:
     build:
@@ -136,7 +136,7 @@ services:
       MONGO_DATABASE: ${MONGO_INITDB_DATABASE}
       MONGO_USERNAME: ${MONGO_USERNAME}
       MONGO_PASSWORD: ${MONGO_PASSWORD}
-      JWKS_URI: ${JWKS_URI}
+      URL: ${URL}
 
   mongo:
     image: mongo:5.0.6

--- a/env.example
+++ b/env.example
@@ -5,10 +5,6 @@ URL=
 CLIENT_ID=
 CLIENT_SECRET=
 
-# JSON web key set domain.
-JWKS_URI=
-JWKS_REFRESH_URI=
-
 # Database name, root username, and root password to be initialized in Docker container.
 MONGO_INITDB_DATABASE=cpr
 MONGO_INITDB_ROOT_USERNAME=


### PR DESCRIPTION
The previous setup that requires IBM's Java Web Token API endpoint to be filled into the `.env` template was unnecessarily convoluted and obscure to find without an understanding of the code base. This PR removed it and integrated it right into the microservices.