### PR TITLE
Added name for images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,14 @@ services:
       args:
         URL: ${URL}
         CLIENT_ID: ${CLIENT_ID}
+    image: cpr-frontend
     container_name: cpr-frontend
     restart: unless-stopped
 
   login:
     build:
       context: ./backend/login-microservice
+    image: cpr-login
     container_name: cpr-login
     restart: unless-stopped
     volumes:
@@ -33,6 +35,7 @@ services:
   course-manager:
     build:
       context: ./backend/course-manager-microservice
+    image: cpr-course-manager
     container_name: cpr-course-manager
     restart: unless-stopped
     environment:
@@ -50,6 +53,7 @@ services:
   course-viewer:
     build:
       context: ./backend/course-viewer-microservice
+    image: cpr-course-viewer
     container_name: cpr-course-viewer
     restart: unless-stopped
     environment:
@@ -67,6 +71,7 @@ services:
   peer-review-teams:
     build:
       context: ./backend/peer-review-teams-microservice
+    image: cpr-peer-review-teams
     container_name: cpr-peer-review-teams
     restart: unless-stopped
     environment:
@@ -84,6 +89,7 @@ services:
   professor-assignment:
     build:
       context: ./backend/professor-assignment-microservice
+    image: cpr-professor-assignment
     container_name: cpr-professor-assignment
     restart: unless-stopped
     volumes:
@@ -103,6 +109,7 @@ services:
   student-assignment:
     build:
       context: ./backend/student-assignment-microservice
+    image: cpr-student-assignment
     container_name: cpr-student-assignment
     restart: unless-stopped
     volumes:
@@ -122,6 +129,7 @@ services:
   student-peer-review-assignment:
     build:
       context: ./backend/student-peer-review-assignment-microservice
+    image: cpr-student-peer-review-assignment
     container_name: cpr-student-peer-review-assignment
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Image names were automatically generated with `app_` followed by the container name, which was unnecessary. This PR made it to be similar with the container names.