### PR TITLE
Professor check algorithm rework

### DIFF
--- a/backend/login-microservice/src/main/java/edu/oswego/cs/application/RestApplication.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/application/RestApplication.java
@@ -1,4 +1,4 @@
-package edu.oswego.cs.rest.application;
+package edu.oswego.cs.application;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/controllers/Controller.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/controllers/Controller.java
@@ -1,17 +1,13 @@
 package edu.oswego.cs.controllers;
 
+import edu.oswego.cs.services.AuthServices;
+
 import javax.annotation.security.RolesAllowed;
 import javax.json.JsonException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-
-import edu.oswego.cs.services.AuthServices;
+import javax.ws.rs.core.*;
 
 
 @Path("/auth")
@@ -19,14 +15,14 @@ public class Controller {
     @POST
     @Path("token/generate")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response generateToken(@Context HttpHeaders request) throws JsonException{
-        if (request.getRequestHeader(HttpHeaders.AUTHORIZATION) == null) 
+    public Response generateToken(@Context HttpHeaders request) throws JsonException {
+        if (request.getRequestHeader(HttpHeaders.AUTHORIZATION) == null)
             return Response.status(Response.Status.FORBIDDEN).entity("No token found.").build();
-        
+
         String authToken = request.getRequestHeader(HttpHeaders.AUTHORIZATION).get(0).split(" ")[1];
         return Response.status(Response.Status.OK).entity(new AuthServices().generateNewToken(authToken)).build();
     }
-    
+
     @POST
     @RolesAllowed("lakers")
     @Path("token/refresh")
@@ -34,5 +30,5 @@ public class Controller {
     public Response refreshToken(@Context SecurityContext securityContext) {
         return Response.status(Response.Status.OK).entity(new AuthServices().refreshToken(securityContext)).build();
     }
-    
+
 }

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/controllers/Controller.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/controllers/Controller.java
@@ -1,4 +1,4 @@
-package edu.oswego.cs.rest.controllers;
+package edu.oswego.cs.controllers;
 
 import javax.annotation.security.RolesAllowed;
 import javax.json.JsonException;
@@ -11,7 +11,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-import edu.oswego.cs.rest.services.AuthServices;
+import edu.oswego.cs.services.AuthServices;
 
 
 @Path("/auth")

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/cors/CorsFilter.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/cors/CorsFilter.java
@@ -1,4 +1,4 @@
-package edu.oswego.cs.rest.cors;
+package edu.oswego.cs.cors;
 
 import java.io.IOException;
 

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/cors/CorsFilter.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/cors/CorsFilter.java
@@ -1,7 +1,5 @@
 package edu.oswego.cs.cors;
 
-import java.io.IOException;
-
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -11,17 +9,10 @@ import javax.ws.rs.ext.Provider;
 public class CorsFilter implements ContainerResponseFilter {
 
     @Override
-    public void filter(ContainerRequestContext requestContext, 
-      ContainerResponseContext responseContext) throws IOException {
-          responseContext.getHeaders().add(
-            "Access-Control-Allow-Origin", "*");
-          responseContext.getHeaders().add(
-            "Access-Control-Allow-Credentials", "true");
-          responseContext.getHeaders().add(
-           "Access-Control-Allow-Headers",
-           "origin, content-type, accept, authorization");
-          responseContext.getHeaders().add(
-            "Access-Control-Allow-Methods", 
-            "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
+        responseContext.getHeaders().add("Access-Control-Allow-Credentials", "true");
+        responseContext.getHeaders().add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization");
+        responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
     }
 }

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/database/DatabaseManager.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/database/DatabaseManager.java
@@ -1,4 +1,4 @@
-package edu.oswego.cs.rest.database;
+package edu.oswego.cs.database;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/database/DatabaseManager.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/database/DatabaseManager.java
@@ -20,6 +20,9 @@ public class DatabaseManager {
     String mongoUser = System.getenv("MONGO_USERNAME");
     String mongoPassword = System.getenv("MONGO_PASSWORD");
 
+    public DatabaseManager() {
+    }
+
     public MongoDatabase getStudentDB() {
         MongoCredential credentials = MongoCredential.createCredential(mongoUser, mongoDatabase, mongoPassword.toCharArray());
         MongoClient client = new MongoClient(
@@ -68,8 +71,5 @@ public class DatabaseManager {
                 new MongoClientOptions.Builder().build()
         );
         return client.getDatabase(mongoDatabase);
-    }
-
-    public DatabaseManager() {
     }
 }

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/database/ProfessorCheck.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/database/ProfessorCheck.java
@@ -1,4 +1,4 @@
-package edu.oswego.cs.rest.database;
+package edu.oswego.cs.database;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/database/ProfessorCheck.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/database/ProfessorCheck.java
@@ -1,94 +1,63 @@
 package edu.oswego.cs.database;
 
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
-import com.mongodb.client.model.Filters;
+import com.mongodb.client.MongoDatabase;
+import edu.oswego.cs.util.CPRException;
 import org.bson.Document;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.mongodb.client.model.Filters.eq;
+
 @ApplicationScoped
 public class ProfessorCheck {
+    private final MongoCollection<Document> professorCollection;
     String reg;
-    DatabaseManager db;
-    MongoCollection<Document> professors;
-    MongoCollection<Document> students;
 
     public ProfessorCheck() throws IOException {
-        db = new DatabaseManager();
-        professors = db.getProfessorDB().getCollection("professors");
-        students = db.getStudentDB().getCollection("students");
+        DatabaseManager databaseManager = new DatabaseManager();
+        try {
+            MongoDatabase professorDB = databaseManager.getProfessorDB();
+            professorCollection = professorDB.getCollection("professors");
+        } catch (WebApplicationException e) {
+            throw new CPRException(Response.Status.BAD_REQUEST, "Failed to retrieve collections.");
+        }
+
+        addProfessor();
+    }
+
+    public void addProfessor() throws IOException {
         String path = getPath();
-        BufferedReader br = new BufferedReader(new FileReader(path + "professor-list.txt"));
-        String line;
-        ArrayList<String> CurrentList = new ArrayList<>();
-        while ((line = br.readLine()) != null) {
-            if (line.contains("@")) CurrentList.add(line.split("@")[0]);
-        }
-        MongoCursor<Document> results = professors.find().iterator();
-        ArrayList<String> OldList = new ArrayList<>();
-        while (results.hasNext()) {
-            OldList.add(results.next().get("professor_id").toString());
-        }
-
-        // Promote any new professors.
-        for (String s : CurrentList) {
-            // Check if there are any student objects by that id if so update the courses of that professor.
-            if (students.find(Filters.eq("student_id", s)).iterator().hasNext()) {
-                Document newProfessor = new Document("professor_id", s);
-                MongoCursor<Document> studentResults = students.find(Filters.eq("student_id", s)).iterator();
-                ArrayList<String> courses = new ArrayList<>();
-                while (studentResults.hasNext()) {
-                    Document oldStudent = studentResults.next();
-                    if (oldStudent.get("courses") != null) {
-                        courses.addAll(oldStudent.getList("courses", String.class));
-                    }
-                }
-                // If they currently have a professor object add to course if there are any.
-                if (professors.find(Filters.eq("professor_id", s)).iterator().hasNext()) {
-                    for (Document oldProfessor : professors.find(Filters.eq("professor_id", s))) {
-                        if (oldProfessor.get("courses") != null) {
-                            courses.addAll(oldProfessor.getList("courses", String.class));
-                        }
-                    }
-                }
-                newProfessor.append("courses", courses);
-                professors.deleteMany(Filters.eq("professor_id", s));
-                professors.insertOne(newProfessor);
-                students.deleteMany(Filters.eq("student_id", s));
-            } else {
-                // If they have no student object, and they are not already a professor make an object.
-                if (!professors.find(Filters.eq("professor_id", s)).iterator().hasNext()) {
-                    Document professorDocument = new Document("professor_id", s);
-                    professorDocument.append("courses", new ArrayList<String>());
-                    professors.insertOne(professorDocument);
-                }
+        var reader = new BufferedReader(new FileReader(path + "professor-list.txt"));
+        String line = reader.readLine();
+        ArrayList<String> professorList = new ArrayList<>();
+        while (line != null) {
+            if (line.contains("@")) {
+                String[] token = line.split("@");
+                professorList.add(token[0]);
             }
+            line = reader.readLine();
         }
-        // Demote any present in Old but not in new.
 
-        for (String s : OldList) {
-            if (!CurrentList.contains(s)) {
-                Document oldProf = professors.find(Filters.eq("professor_id", s)).first();
-                if (oldProf != null) {
-                    Document newStudent = new Document("student_id", s);
-                    if (oldProf.get("courses") != null) {
-                        List<String> courses = oldProf.getList("courses", String.class);
-                        newStudent.append("courses", courses);
-                    }
-                    students.insertOne(newStudent);
-                }
-                professors.deleteMany(Filters.eq("professor_id", s));
+        for (String professorID : professorList) {
+            Document professorDocument = professorCollection.find(eq("professor_id", professorID)).first();
+            if (professorDocument == null) {
+                List<String> courseList = new ArrayList<>();
+                Document newProfessor = new Document()
+                        .append("professor_id", professorID)
+                        .append("courses", courseList);
+                professorCollection.insertOne(newProfessor);
             }
         }
 
-
-        br.close();
+        reader.close();
     }
 
     public String getPath() {
@@ -100,10 +69,12 @@ public class ProfessorCheck {
         for (int i = slicedPath.length - 1; !slicedPath[i].equals(targetDir); i--) {
             relativePathPrefix.append("../");
         }
+
         if (System.getProperty("user.dir").contains("\\")) {
             reg = "//";
             relativePathPrefix = new StringBuilder(relativePathPrefix.toString().replace("/", "\\"));
         }
+
         return relativePathPrefix.toString();
     }
 }

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/rest/database/ProfessorCheck.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/rest/database/ProfessorCheck.java
@@ -39,44 +39,43 @@ public class ProfessorCheck {
         // Promote any new professors.
         for (String s : CurrentList) {
             // Check if there are any student objects by that id if so update the courses of that professor.
-             if (students.find(Filters.eq("student_id", s)).iterator().hasNext()) {
-                 Document newProfessor = new Document("professor_id", s);
-                 MongoCursor<Document> studentResults = students.find(Filters.eq("student_id", s)).iterator();
-                 ArrayList<String> courses = new ArrayList<>();
-                 while (studentResults.hasNext()) {
-                     Document oldStudent = studentResults.next();
-                     if (oldStudent.get("courses") != null) {
-                         courses.addAll(oldStudent.getList("courses",String.class));
-                     }
-                 }
-                 // If they currently have a professor object add to course if there are any.
-                 if (professors.find(Filters.eq("professor_id", s)).iterator().hasNext()) {
-                     for (Document oldProfessor : professors.find(Filters.eq("professor_id", s))) {
-                         if (oldProfessor.get("courses") != null) {
-                             courses.addAll(oldProfessor.getList("courses", String.class));
-                         }
-                     }
-                 }
-                 newProfessor.append("courses", courses);
-                 professors.deleteMany(Filters.eq("professor_id", s));
-                 professors.insertOne(newProfessor);
-                 students.deleteMany(Filters.eq("student_id", s));
-             } else {
+            if (students.find(Filters.eq("student_id", s)).iterator().hasNext()) {
+                Document newProfessor = new Document("professor_id", s);
+                MongoCursor<Document> studentResults = students.find(Filters.eq("student_id", s)).iterator();
+                ArrayList<String> courses = new ArrayList<>();
+                while (studentResults.hasNext()) {
+                    Document oldStudent = studentResults.next();
+                    if (oldStudent.get("courses") != null) {
+                        courses.addAll(oldStudent.getList("courses", String.class));
+                    }
+                }
+                // If they currently have a professor object add to course if there are any.
+                if (professors.find(Filters.eq("professor_id", s)).iterator().hasNext()) {
+                    for (Document oldProfessor : professors.find(Filters.eq("professor_id", s))) {
+                        if (oldProfessor.get("courses") != null) {
+                            courses.addAll(oldProfessor.getList("courses", String.class));
+                        }
+                    }
+                }
+                newProfessor.append("courses", courses);
+                professors.deleteMany(Filters.eq("professor_id", s));
+                professors.insertOne(newProfessor);
+                students.deleteMany(Filters.eq("student_id", s));
+            } else {
                 // If they have no student object, and they are not already a professor make an object.
                 if (!professors.find(Filters.eq("professor_id", s)).iterator().hasNext()) {
                     Document professorDocument = new Document("professor_id", s);
                     professorDocument.append("courses", new ArrayList<String>());
                     professors.insertOne(professorDocument);
                 }
-             }
+            }
         }
         // Demote any present in Old but not in new.
 
         for (String s : OldList) {
             if (!CurrentList.contains(s)) {
-
                 Document oldProf = professors.find(Filters.eq("professor_id", s)).first();
-                if(oldProf != null){
+                if (oldProf != null) {
                     Document newStudent = new Document("student_id", s);
                     if (oldProf.get("courses") != null) {
                         List<String> courses = oldProf.getList("courses", String.class);
@@ -84,7 +83,6 @@ public class ProfessorCheck {
                     }
                     students.insertOne(newStudent);
                 }
-
                 professors.deleteMany(Filters.eq("professor_id", s));
             }
         }

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/services/AuthServices.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/services/AuthServices.java
@@ -9,26 +9,20 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import edu.oswego.cs.database.DatabaseManager;
 import edu.oswego.cs.database.ProfessorCheck;
-
 import org.bson.Document;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
-
 import java.security.Principal;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static com.mongodb.client.model.Filters.eq;
 
 public class AuthServices {
-    private MongoCollection<Document> professorCollection;
     GoogleService googleService = new GoogleService();
+    private MongoCollection<Document> professorCollection;
 
     public AuthServices() {
         DatabaseManager databaseManager = new DatabaseManager();
@@ -43,14 +37,14 @@ public class AuthServices {
 
     public Map<String, String> generateNewToken(String token) {
         Payload payload = googleService.validateToken(token);
-        if (payload == null) 
+        if (payload == null)
             throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Invalid token.").build());
-        
+
         Map<String, String> tokens = new HashMap<>();
-        
+
         String lakerID = payload.getEmail().split("@")[0];
         Set<String> roles = getRoles(lakerID);
-        
+
         try {
             String access_token = JwtBuilder.create("cpr_access")
                     .claim("sub", payload.getSubject())
@@ -73,7 +67,7 @@ public class AuthServices {
 
             tokens.put("access_token", access_token);
             tokens.put("refresh_token", refresh_token);
-            
+
             return tokens;
 
         } catch (JwtException | InvalidBuilderException | InvalidClaimException e) {
@@ -85,14 +79,14 @@ public class AuthServices {
     public Map<String, String> refreshToken(SecurityContext securityContext) {
         Principal user = securityContext.getUserPrincipal();
         JsonWebToken payload = (JsonWebToken) user;
-        if (payload == null) 
+        if (payload == null)
             throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("JWT is not available.").build());
-        
+
         Map<String, String> tokens = new HashMap<>();
 
         String lakerID = payload.getName().split("@")[0];
         Set<String> roles = getRoles(lakerID);
-        
+
         try {
             String access_token = JwtBuilder.create("cpr_access")
                     .claim("sub", payload.getSubject())
@@ -114,13 +108,13 @@ public class AuthServices {
 
     public Set<String> getRoles(String lakerID) {
         Set<String> roles = new HashSet<>();
-        
+
         if (professorCollection.find(eq("professor_id", lakerID)).first() != null) {
             roles.add("professor");
         } else {
             roles.add("student");
         }
-        if (roles.size() == 0) 
+        if (roles.size() == 0)
             throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Can't connect to database.").build());
 
         return roles;

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/services/AuthServices.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/services/AuthServices.java
@@ -1,4 +1,4 @@
-package edu.oswego.cs.rest.services;
+package edu.oswego.cs.services;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.ibm.websphere.security.jwt.InvalidBuilderException;
@@ -7,8 +7,8 @@ import com.ibm.websphere.security.jwt.JwtBuilder;
 import com.ibm.websphere.security.jwt.JwtException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import edu.oswego.cs.rest.database.DatabaseManager;
-import edu.oswego.cs.rest.database.ProfessorCheck;
+import edu.oswego.cs.database.DatabaseManager;
+import edu.oswego.cs.database.ProfessorCheck;
 
 import org.bson.Document;
 import org.eclipse.microprofile.jwt.JsonWebToken;

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/services/GoogleService.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/services/GoogleService.java
@@ -18,9 +18,9 @@ public class GoogleService {
 
     protected Payload validateToken(String token) {
         GoogleIdToken idToken = verifyToken(token);
-        if (idToken == null) 
+        if (idToken == null)
             throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Invalid token.").build());
-        
+
         return idToken.getPayload();
     }
 

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/services/GoogleService.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/services/GoogleService.java
@@ -1,4 +1,4 @@
-package edu.oswego.cs.rest.services;
+package edu.oswego.cs.services;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;

--- a/backend/login-microservice/src/main/java/edu/oswego/cs/util/CPRException.java
+++ b/backend/login-microservice/src/main/java/edu/oswego/cs/util/CPRException.java
@@ -1,0 +1,10 @@
+package edu.oswego.cs.util;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+public class CPRException extends WebApplicationException {
+    public CPRException(Response.Status responseStatus, String errorMessage) {
+        super(Response.status(responseStatus).entity(errorMessage).build());
+    }
+}


### PR DESCRIPTION
Reworked the algorithm to fix #254 as following:
- Previously, the algorithm would attempt to promote/demote people from a student to a professor and vice versa, and also attempt to migrate the courses that the student might be taking into a course they would teach as a professor using the input email from `professor-list.txt`. This turned out to be impractical because the student ID is not the same as the professor ID syntactically, e.g. "John Doe" as a student would be "jdoe" but "john.doe" as a professor. A student can also be a professor at the same time because there are two view panes to switch between both, proving this to be unnecessarily complicated.

The best and cleanest way to do this is to just remove them as a student rather than overengineering it.