### PR TITLE
Fixed course id issue

### DIFF
--- a/discord/src/utils.js
+++ b/discord/src/utils.js
@@ -40,14 +40,16 @@ module.exports = {
         };
 
         auth.roles = decode(token).groups;
-        auth.courseId = await axios
-            .get('http://course-viewer:13128/view/professor/courses', auth.headers)
-            .then((res) => {
-                return res.data.find(course => course.course_name === interaction.guild.name).course_id;
-            })
-            .catch((err) => {
-                console.error(err.stack);
-            });
+        auth.courseId = interaction.guild.name;
+
+        // auth.courseId = await axios
+        //     .get('http://course-viewer:13128/view/professor/courses', auth.headers)
+        //     .then((res) => {
+        //         return res.data.find(course => course.course_name === interaction.guild.name).course_id;
+        //     })
+        //     .catch((err) => {
+        //         console.error(err.stack);
+        //     });
 
         return auth;
     },


### PR DESCRIPTION
Course Id now comes from the Discord server name instead of using the course name and backend routes